### PR TITLE
Catch the error : "no prior cheque"

### DIFF
--- a/build/wizard/src/pages/home/components/SwarmInfo.js
+++ b/build/wizard/src/pages/home/components/SwarmInfo.js
@@ -59,10 +59,14 @@ const Comp = ({ session }) => {
     const getLastCashedPayout = (peer) => {
         return axios.get(`${endpoint}/chequebook/cashout/${peer}`, {
         }).then((res) => {
-            if (!res.data || !res.data.cumulativePayout) {
+            if (!res.data.cumulativePayout) {
                 return 0;
             }
             return res.data.cumulativePayout;
+        }).catch((err) => {
+            if (err.response.data.message === "no prior cheque")  {
+                return 0;
+            }  
         });
     }
 


### PR DESCRIPTION
When there is no prior cheque from a peer, res.data won't return "null". It will return an "404 error". "error" must be handled by catch(). I only "catch" the "no prior cheque" error. Other errors may need to be “catch” in the future. Although I don't think “!res.data.cumulativePayout” is useful, I'll keep it for the sake of safety.